### PR TITLE
Fix error where invalid username passed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.2.1 (2022-03-14)
+
+### Fixed
+
+-   Fix issue where a bad username would throw the wrong error due to a change with the BoxRec error message. 
+    Error now just checks if the login returns the login form
+
 ## 5.2.0 (2022-02-22)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxrec-requests",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "make API requests to BoxRec using NodeJS and returns the HTML body",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/boxrec-requests.spec.e2e.ts
+++ b/src/boxrec-requests.spec.e2e.ts
@@ -44,7 +44,7 @@ describe("class BoxrecRequests", () => {
             cookieString = cookieBuffer.toString();
             cookieJar.setCookie(cookieString, cookieDomain);
         } catch (e) {
-            // if the file doesn't exist, we login and store the cookie in the "../tmp" directory
+            // if the file doesn't exist, we log in and store the cookie in the "../tmp" directory
             cookieJar = await BoxrecRequests.login(BOXREC_USERNAME, BOXREC_PASSWORD);
             const newCookieString: string = cookieJar.getCookieString(cookieDomain);
             await fs.writeFileSync(tmpPath, newCookieString);
@@ -59,12 +59,24 @@ describe("class BoxrecRequests", () => {
         wait(done);
     });
 
-    it("Bad password should throw an error", async () => {
-        try {
-            await BoxrecRequests.login(BOXREC_USERNAME, "");
-        } catch (e) {
-            expect(e.message).toBe("Your password is incorrect");
-        }
+    describe("method login", () => {
+
+        it("Bad username should throw an error stating bad credentials because of returning to a page with the login form", async () => {
+            try {
+                await BoxrecRequests.login("", "");
+            } catch (e) {
+                expect(e.message).toBe("Please check your credentials, could not log into BoxRec");
+            }
+        });
+
+        it("Bad password should throw stating bad credentials because of returning to a page with the login form", async () => {
+            try {
+                await BoxrecRequests.login("boxrec", "");
+            } catch (e) {
+                expect(e.message).toBe("Please check your credentials, could not log into BoxRec");
+            }
+        });
+
     });
 
     it("cookie should be not null and defined", () => {

--- a/src/boxrec-requests.ts
+++ b/src/boxrec-requests.ts
@@ -450,13 +450,10 @@ export class BoxrecRequests {
         }
 
         // the following are when login has failed
-        // an unsuccessful login returns a 200, we'll look for phrases to determine the error
-        if (data.body.includes("your password is incorrect")) {
-            errorMessage = "Your password is incorrect";
-        }
-
-        if (data.body.includes("username does not exist")) {
-            errorMessage = "Username does not exist";
+        // an unsuccessful login returns a 200
+        const $: CheerioStatic = cheerio.load(data.body);
+        if ($("input#username").length) {
+            errorMessage = "Please check your credentials, could not log into BoxRec";
         }
 
         if (data.statusCode !== 200 || errorMessage !== "") {


### PR DESCRIPTION
BoxRec used to display "username does not exist" when a username did not exist, but now shows "invalid credentials supplied".

This was figured out from [here](https://github.com/boxing/boxrec/issues/252#issuecomment-1067408339).

This fix just checks if the input that is a username field reappears, meaning log in failed.

Picture of now failed username
![image](https://user-images.githubusercontent.com/5728044/158280690-19ea9fe1-dac7-4c1a-814a-7664dd63d885.png)
