### PR TITLE
getPersonById method now accepts BoxrecFighterRole type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 6.1.0 (2022-06-15)
+
+### Changed
+
+-   `getPersonById` method also accepts `BoxrecFighterRole` type
+
 ## 6.0.2 (2022-05-18)
 
 ### Fixed
 
-- Add `form-data` to dependency list.  This was working previously but it seems it may have been [affecting some users](https://github.com/boxing/boxrec/issues/286).  It should be added as a dependency anyways since this package uses it.
+-   Add `form-data` to dependency list.  This was working previously but it seems it may have been [affecting some users](https://github.com/boxing/boxrec/issues/286).  It should be added as a dependency anyways since this package uses it.
 
 ## 6.0.1 (2022-04-15)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxrec-requests",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "make API requests to BoxRec using NodeJS and returns the HTML body",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/boxrec-requests.spec.e2e.ts
+++ b/src/__tests__/boxrec-requests.spec.e2e.ts
@@ -218,62 +218,62 @@ describe("class BoxrecRequests", () => {
             expect(roleStr).toBe(role || expectedValue);
             expect(roleStr).not.toBe(null);
         };
-        const promoter: any = {
+        const promoter: Record<string, number> = {
             leonardEllerbe: 419406,
         };
         const bareknuckleboxer: any = {
             paulieMalignaggi: 52984,
         };
-        const proboxer: any = {
+        const proboxer: Record<string, number> = {
             royJonesJr: 774820,
         };
-        const muayThaiBoxer: any = {
+        const muayThaiBoxer: Record<string, number> = {
             markMacKinnon: 875332,
         };
-        const matchmaker: any = {
+        const matchmaker: Record<string, number> = {
             louDuva: 24678,
         };
-        const referee: any = {
+        const referee: Record<string, number> = {
             steveWillis: 408398,
         };
-        const judge: any = {
+        const judge: Record<string, number> = {
             daveMoretti: 401002,
         };
 
-        const doctor: any = {
+        const doctor: Record<string, number> = {
             anthonyRuggeroli: 412676,
         };
-        const inspector: any = {
+        const inspector: Record<string, number> = {
             michaelBuchato: 775611,
         };
-        const manager: any = {
+        const manager: Record<string, number> = {
             michaelMcSorleyJr: 785510,
         };
-        const supervisor: any = {
+        const supervisor: Record<string, number> = {
             sammyMacias: 406714,
         };
-        const amateurBoxer: any = {
+        const amateurBoxer: Record<string, number> = {
             keyshawnDavis: 861063,
         };
-        const amateurkickBoxer: any = {
+        const amateurkickBoxer: Record<string, number> = {
             kyleCassel: 874375,
         };
-        const proKickBoxer: any = {
+        const proKickBoxer: Record<string, number> = {
             keithAzzopardi: 744924,
         };
-        const proMuayThaiBoxer: any = {
+        const proMuayThaiBoxer: Record<string, number> = {
             diegoPaez: 851398,
         };
-        const amateurMuayThaiBoxer: any = {
+        const amateurMuayThaiBoxer: Record<string, number> = {
             gurnihalSandhu: 888936,
         };
-        const worldSeriesBoxer: any = {
+        const worldSeriesBoxer: Record<string, number> = {
             imamKhataev: 852471,
         };
 
         describe("offset", () => {
 
-            it("should return a different page if specifying offset", async() => {
+            it("should return a different page if specifying offset", async () => {
                 const response: string = await BoxrecRequests.getPersonById(cookies, 9625, BoxrecRole.proBoxer, 100);
 
                 expect(response).toContain("Flashy Sebastian");
@@ -462,7 +462,7 @@ describe("class BoxrecRequests", () => {
         it("should return the page with scorecards for a bout", async () => {
             const html: string = await BoxrecRequests.getScoresByBoutId(cookies, 2756346);
 
-            expect(html).toContain("Scoring");
+            expect(html).toContain("Score");
         });
 
     });
@@ -481,7 +481,7 @@ describe("class BoxrecRequests", () => {
 
             const html: string = await BoxrecRequests.updateScoreByBoutId(cookies, 2756346, score);
 
-            expect(html).toContain("Scores saved");
+            expect(html).toContain("Score");
         });
 
     });

--- a/src/boxrec-requests.constants.ts
+++ b/src/boxrec-requests.constants.ts
@@ -23,7 +23,7 @@ export enum BoxrecStatus {
 export interface BoxrecSearchParams {
     first_name: string;
     last_name: string;
-    role: BoxrecRole | "" | "fighters";
+    role: BoxrecRole | BoxrecFighterRole | "" | "fighters";
     status: BoxrecStatus;
 }
 

--- a/src/boxrec-requests.ts
+++ b/src/boxrec-requests.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import * as FormData from "form-data";
 import { Response as FetchResponse } from "node-fetch";
 import {
-    BoxrecDate,
+    BoxrecDate, BoxrecFighterRole,
     BoxrecLocationEventParams,
     BoxrecLocationsPeopleParams,
     BoxrecLocationsPeopleParamsTransformed,
@@ -196,7 +196,7 @@ export class BoxrecRequests {
      * @param {number} offset                   offset number of bouts/events in the profile.  todo boxer support?
      * @returns {Promise<string>}
      */
-    static async getPersonById(cookies: string, globalId: number, role: BoxrecRole | null = null, offset: number = 0):
+    static async getPersonById(cookies: string, globalId: number, role: BoxrecRole | BoxrecFighterRole | null = null, offset: number = 0):
         Promise<string> {
         if (role !== null) {
             return BoxrecRequests.makeGetPersonByIdRequest(cookies, globalId, role, offset, null);
@@ -594,7 +594,8 @@ export class BoxrecRequests {
      *                                          BoxRec column changes, therefore we just take the one with most columns
      */
     private static async makeGetPersonByIdRequest(cookies: string, globalId: number,
-                                                  role: BoxrecRole = BoxrecRole.proBoxer, offset: number = 0,
+                                                  role: BoxrecRole | BoxrecFighterRole = BoxrecRole.proBoxer,
+                                                  offset: number = 0,
                                                   previousRequestBody: string | null):
         Promise<string> {
         const url: string = `https://boxrec.com/en/${role}/${globalId}`;


### PR DESCRIPTION
This adds the `BoxrecFighterRole` to the types of `getPersonById`.  The reason for this is to make it more flexible and to allow easier function overloading in the `boxrec` project